### PR TITLE
Add colors in console and label

### DIFF
--- a/lib/core.ex
+++ b/lib/core.ex
@@ -23,7 +23,7 @@ defmodule Twitchbot.LoginHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.magenta() <> "[TWITCH] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end
 
@@ -109,6 +109,6 @@ defmodule Twitchbot.EventsHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.magenta() <> "[TWITCH] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end

--- a/lib/twitchbot.ex
+++ b/lib/twitchbot.ex
@@ -92,6 +92,6 @@ defmodule ConnectionHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.magenta() <> "[TWITCH] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end

--- a/lib/whispers_client.ex
+++ b/lib/whispers_client.ex
@@ -46,7 +46,7 @@ defmodule Twitch.Whispers do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> "[WHISPERS] " <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.green() <> "[WHISPERS] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end
 
@@ -75,7 +75,7 @@ defmodule WhispersLoginHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> "[WHISPERS] " <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.green() <> "[WHISPERS] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end
 
@@ -121,7 +121,7 @@ defmodule WhispersConnectionHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> "[WHISPERS] " <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.green() <> "[WHISPERS] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end
 
@@ -154,6 +154,6 @@ defmodule WhispersEventsHandler do
   end
 
   defp debug(msg) do
-    IO.puts IO.ANSI.yellow() <> "[WHISPERS] " <> msg <> IO.ANSI.reset()
+    IO.puts IO.ANSI.green() <> "[WHISPERS] " <> IO.ANSI.yellow() <> msg <> IO.ANSI.reset()
   end
 end


### PR DESCRIPTION
Add `[TWITCH]` to the twitch client's debug messages as well as add some console colors for easier distinction between each client.